### PR TITLE
Switch IDP from TelenorID to TelenorID+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Telenor-ID-iOS-SDK",
+    platforms: [.iOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/Telenor-ID-iOS-SDK/Network/Models/Endpoint.swift
+++ b/Sources/Telenor-ID-iOS-SDK/Network/Models/Endpoint.swift
@@ -1,22 +1,18 @@
 import Foundation
 
 enum Endpoint: String {
-    case authorization = "/oauth/authorize",
-        token = "/oauth/token",
-        tokeninfo = "/oauth/tokeninfo",
-        userinfo = "/oauth/userinfo",
-        revoke = "/oauth/revoke",
-        logout = "/oauth/logout",
-        wellKnown = "/oauth/.well-known/openid-configuration",
-        issuer = "/oauth",
-        selfService = "/overview"
+    case authorization = "/connect/authorize",
+        token = "/connect/token",
+        userinfo = "/connect/userinfo",
+        revoke = "/oauth/revoke", // TODO(serhii): not there yet?
+        logout = "/v1/logout",
+        wellKnown = "/.well-known/openid-configuration",
+        issuer = ""
 
     func callAsFunction(_ configuration: Configuration) -> URLComponents {
         var urlComponents = URLComponents()
         urlComponents.scheme = "https"
-        urlComponents.host = self == .selfService
-        ? Host.getSelfServiceHost(environment: configuration.environment)
-        : Host.getIdHost(environment: configuration.environment)
+        urlComponents.host = Host.getIdHost(environment: configuration.environment)
         urlComponents.path = self.rawValue
         return urlComponents
     }

--- a/Sources/Telenor-ID-iOS-SDK/Network/Models/Host.swift
+++ b/Sources/Telenor-ID-iOS-SDK/Network/Models/Host.swift
@@ -1,12 +1,31 @@
 import Foundation
 
 enum Host: String {
-    case idProduction = "signin.telenorid.com",
-        idStaging = "signin.telenorid-staging.com",
-        idTest = "signin.telenorid-test.com",
+    case idProduction = "id.telenor.no",
+        idStaging = "id-test.telenor.no",
         selfServiceProduction = "manage.telenorid.com",
         selfServiceStaging = "manage.telenorid-staging.com",
-        selfServiceTest = "manage.telenorid-test.com"
+        selfServiceTest = "manage.telenorid-test.com",
+        legacyIdProduction = "signin.telenorid.com",
+        legacyIdStaging = "signin.telenorid-staging.com",
+        legacyIdTest = "signin.telenorid-test.com"
+    
+    public func isSelfService() -> Bool {
+        return self == .selfServiceProduction
+        || self == .selfServiceStaging
+        || self == .selfServiceTest
+    }
+    
+    public static func getLegacyIdHost(environment: Environment) -> String {
+        switch environment {
+        case .production:
+            return legacyIdProduction.rawValue
+        case .staging:
+            return legacyIdStaging.rawValue
+        case .test:
+            return legacyIdTest.rawValue
+        }
+    }
 
     public static func getIdHost(environment: Environment) -> String {
         switch environment {
@@ -15,7 +34,7 @@ enum Host: String {
         case .staging:
             return idStaging.rawValue
         case .test:
-            return idTest.rawValue
+            return idStaging.rawValue
         }
     }
 
@@ -28,5 +47,12 @@ enum Host: String {
         case .test:
             return selfServiceTest.rawValue
         }
+    }
+    
+    public static func getSelfServiceUrlComponents(environment: Environment) -> URLComponents {
+        var urlComponents = URLComponents()
+        urlComponents.scheme = "https"
+        urlComponents.host = Host.getIdHost(environment: environment)
+        return urlComponents
     }
 }

--- a/Sources/Telenor-ID-iOS-SDK/Network/Models/Parameter.swift
+++ b/Sources/Telenor-ID-iOS-SDK/Network/Models/Parameter.swift
@@ -24,7 +24,11 @@ enum Parameter: String, Encodable {
         telenordigitalSdkVersion = "telenordigital_sdk_version",
         telenordigitalDid = "telenordigital_did",
         logSessionId = "log_session_id",
-        token = "token"
+        token = "token",
+        codeChallenge = "code_challenge",
+        codeChallengeMethod = "code_challenge_method",
+        codeVerifier = "code_verifier",
+        idTokenHint = "id_token_hint"
 
     func callAsFunction() -> String {
         return self.rawValue

--- a/Sources/Telenor-ID-iOS-SDK/Network/NetworkServiceError.swift
+++ b/Sources/Telenor-ID-iOS-SDK/Network/NetworkServiceError.swift
@@ -4,5 +4,5 @@ public enum NetworkServiceError: Error {
     case invalidCode,
         essentialClaimsParsingException,
         unsuccessfulResponse(message: String?),
-        accessTokenMissingAtLogout
+        idTokenMissingAtLogout
 }

--- a/Sources/Telenor-ID-iOS-SDK/TelenorIdSdk.swift
+++ b/Sources/Telenor-ID-iOS-SDK/TelenorIdSdk.swift
@@ -31,7 +31,7 @@ public enum TelenorIdSdk {
                 Call `TelenorIdSdk.useConfiguration()` before accessing shared instance.
             """)
         }
-        var urlComponents = Endpoint.selfService(configuration)
+        var urlComponents = Host.getSelfServiceUrlComponents(environment: configuration.environment)
         urlComponents.queryItems = [
             URLQueryItem(name: Parameter.uiLocales(), value: uiLocales.joined(separator: " "))
         ]

--- a/Sources/Telenor-ID-iOS-SDK/Utils/Utils.swift
+++ b/Sources/Telenor-ID-iOS-SDK/Utils/Utils.swift
@@ -1,0 +1,37 @@
+import Foundation
+import CryptoKit
+
+// CryptoKit.Digest utils
+extension Digest {
+    var bytes: [UInt8] { Array(makeIterator()) }
+    var data: Data { Data(bytes) }
+
+    var hexStr: String {
+        bytes.map { String(format: "%02X", $0) }.joined()
+    }
+}
+
+public extension Data {
+    init?(base64urlEncoded input: String) {
+        var base64 = input
+        base64 = base64.replacingOccurrences(of: "-", with: "+")
+        base64 = base64.replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 {
+            base64 = base64.appending("=")
+        }
+        self.init(base64Encoded: base64)
+    }
+
+    func base64urlEncodedString() -> String {
+        var result = self.base64EncodedString()
+        result = result.replacingOccurrences(of: "+", with: "-")
+        result = result.replacingOccurrences(of: "/", with: "_")
+        result = result.replacingOccurrences(of: "=", with: "")
+        return result
+    }
+}
+
+public func createRandomString() -> String {
+    let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    return String((0 ..< 64).map { _ in letters.randomElement() ?? Character("") })
+}

--- a/Sources/Telenor-ID-iOS-SDK/Validation/Validator.swift
+++ b/Sources/Telenor-ID-iOS-SDK/Validation/Validator.swift
@@ -36,33 +36,13 @@ public enum Validator {
             """)
         }
 
-        guard let audience = token["aud"] as? [String] else {
+        guard let audience = token["aud"] as? String else {
             throw IdTokenValidationError.missingAudience("ID token audience was nil.")
         }
 
-        if !audience.contains(expectedAudience) {
+        if audience != expectedAudience {
             throw IdTokenValidationError.missingAudience("""
                 ID token audience list does not contain the configured client ID.
-            """)
-        }
-
-        let untrustedAudiences = audience.filter { (str: String) -> Bool in
-            str != expectedAudience
-        }
-        if !untrustedAudiences.isEmpty {
-            throw IdTokenValidationError.untrustedAudiences("ID token audience list contains untrusted audiences.")
-        }
-
-        let authorizedParty: String? = token["azp"] as? String
-        if audience.count > 1 && authorizedParty == nil {
-            throw IdTokenValidationError.authorizedPartyMissing("""
-                ID token contains multiple audiences but no azp claim is present.
-            """)
-        }
-
-        if audience.count > 1 && authorizedParty != expectedAudience {
-            throw IdTokenValidationError.authorizedPartyMismatch("""
-                ID token authorized party is not the configured client ID.
             """)
         }
 


### PR DESCRIPTION
Switch IDP from TelenorID to TelenorID+

Changes compared to previous version:
- Minimum supported version is set to 13
- Code targeting older versions is removed
- New domain for IDP
- New endpoints
- API adjustments to follow ID+
	- Added code verifier and related changes
	- Audience in ID token is a single string, not an array. Validation adjusted
	- Revoke endpoint is in a bad shape, therefor code using it is commented out
	- Logout endpoint is using ID token instead of access token
